### PR TITLE
Add travis configuration sourced from lubdridate/.travis.yaml

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,12 @@
+dist: trusty
+sudo: false
+language: R
+cache: packages
+
+r:
+- oldrel
+- release
+- devel
+
+after_success:
+  - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
Brand new to Travis-CI so I used the `.travis.yaml` configuration settings used by the [lubridate](https://github.com/tidyverse/lubridate) package as the maintainers there are like what I want to be when I grow up to be an R Star.